### PR TITLE
Add Absolute Wedge Fraction Obstructions

### DIFF
--- a/config/grafana/provisioning/dashboards/starlink.json
+++ b/config/grafana/provisioning/dashboards/starlink.json
@@ -16,8 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 4,
-  "iteration": 1621423064407,
+  "iteration": 1623152195373,
   "links": [
     {
       "icon": "info",
@@ -127,7 +126,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
           "exemplar": true,
@@ -185,7 +184,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
           "exemplar": true,
@@ -244,7 +243,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
           "exemplar": true,
@@ -302,7 +301,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
           "exemplar": true,
@@ -360,7 +359,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
           "exemplar": true,
@@ -423,7 +422,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
           "exemplar": true,
@@ -504,7 +503,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
           "exemplar": true,
@@ -588,7 +587,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
           "exemplar": true,
@@ -678,7 +677,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -826,7 +825,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
           "exemplar": true,
@@ -891,7 +890,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
           "exemplar": true,
@@ -1069,101 +1068,167 @@
       "type": "ae3e-plotly-panel"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": "Prometheus",
+      "description": "",
       "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        },
+        "defaults": {},
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 4,
       "gridPos": {
-        "h": 5,
+        "h": 6,
         "w": 6,
         "x": 18,
         "y": 13
       },
-      "hiddenSeries": false,
-      "id": 37,
-      "interval": null,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
+      "id": 53,
       "options": {
-        "alertThreshold": true
+        "config": {
+          "displayModeBar": false
+        },
+        "data": [
+          {
+            "line": {
+              "color": "red",
+              "width": 2
+            },
+            "mode": "lines",
+            "type": "scatter"
+          }
+        ],
+        "layout": {
+          "font": {
+            "color": "darkgrey"
+          },
+          "margin": {
+            "b": 20,
+            "t": 30
+          },
+          "paper_bgcolor": "rgba(0,0,0,0)",
+          "plot_bgcolor": "rgba(0,0,0,0)",
+          "xaxis": {
+            "autorange": false,
+            "range": [
+              "2000-06-13 20:19:55.8287",
+              "2000-06-18 15:40:49.7421"
+            ],
+            "type": "date"
+          }
+        },
+        "onclick": "\n\n",
+        "script": "var data = [\n    {\n        r: [data.series[0].fields[1].values.buffer[0] * 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n        theta: [\"0\", \"30\", \"60\", \"90\", \"120\", \"150\", \"180\", \"210\", \"240\", \"270\", \"300\", \"330\"],\n        name: \"0°-30°\",\n        marker: {color: \"rgb(255,0,0)\"},\n        type: \"barpolar\",\n        showlegend: false,\n        offset: 0,\n        hovertext: \"Obstructions between 0° and 30°\",\n        hoverinfo: \"text+r\"\n    },\n    {\n        r: [0, data.series[1].fields[1].values.buffer[0] * 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n        theta: [\"0\", \"30\", \"60\", \"90\", \"120\", \"150\", \"180\", \"210\", \"240\", \"270\", \"300\", \"330\"],\n        name: \"30°-60°\",\n        marker: {color: \"rgb(255,125,0)\"},\n        type: \"barpolar\",\n        showlegend: false,\n        offset: 0,\n        hovertext: \"Obstructions between 30° and 60°\",\n        hoverinfo: \"text+r\"\n    },\n    {\n        r: [0, 0, data.series[2].fields[1].values.buffer[0] * 100, 0, 0, 0, 0, 0, 0, 0, 0, 0],\n        theta: [\"0\", \"30\", \"60\", \"90\", \"120\", \"150\", \"180\", \"210\", \"240\", \"270\", \"300\", \"330\"],\n        name: \"60°-90°\",\n        marker: {color: \"rgb(255,225,0)\"},\n        type: \"barpolar\",\n        showlegend: false,\n        offset: 0,\n        hovertext: \"Obstructions between 60° and 90°\",\n        hoverinfo: \"text+r\"\n    },\n    {\n        r: [0, 0, 0, data.series[3].fields[1].values.buffer[0] * 100, 0, 0, 0, 0, 0, 0, 0, 0],\n        theta: [\"0\", \"30\", \"60\", \"90\", \"120\", \"150\", \"180\", \"210\", \"240\", \"270\", \"300\", \"330\"],\n        name: \"90°-120°\",\n        marker: {color: \"rgb(125,255,0)\"},\n        type: \"barpolar\",\n        showlegend: false,\n        offset: 0,\n        hovertext: \"Obstructions between 90° and 120°\",\n        hoverinfo: \"text+r\"\n    },\n    {\n        r: [0, 0, 0, 0, data.series[4].fields[1].values.buffer[0] * 100, 0, 0, 0, 0, 0, 0, 0],\n        theta: [\"0\", \"30\", \"60\", \"90\", \"120\", \"150\", \"180\", \"210\", \"240\", \"270\", \"300\", \"330\"],\n        name: \"120°-150°\",\n        marker: {color: \"rgb(0,255,0)\"},\n        type: \"barpolar\",\n        showlegend: false,\n        offset: 0,\n        hovertext: \"Obstructions between 120° and 150°\",\n        hoverinfo: \"text+r\"\n    },\n    {\n        r: [0, 0, 0, 0, 0, data.series[5].fields[1].values.buffer[0] * 100, 0, 0, 0, 0, 0, 0],\n        theta: [\"0\", \"30\", \"60\", \"90\", \"120\", \"150\", \"180\", \"210\", \"240\", \"270\", \"300\", \"330\"],\n        name: \"150°-180°\",\n        marker: {color: \"rgb(0,255,125)\"},\n        type: \"barpolar\",\n        showlegend: false,\n        offset: 0,\n        hovertext: \"Obstructions between 150° and 180°\",\n        hoverinfo: \"text+r\"\n    },\n    {\n        r: [0, 0, 0, 0, 0, 0, data.series[6].fields[1].values.buffer[0] * 100, 0, 0, 0, 0, 0],\n        theta: [\"0\", \"30\", \"60\", \"90\", \"120\", \"150\", \"180\", \"210\", \"240\", \"270\", \"300\", \"330\"],\n        name: \"180°-210°\",\n        marker: {color: \"rgb(0,255,255)\"},\n        type: \"barpolar\",\n        showlegend: false,\n        offset: 0,\n        hovertext: \"Obstructions between 180° and 210°\",\n        hoverinfo: \"text+r\"\n    },\n    {\n        r: [0, 0, 0, 0, 0, 0, 0, data.series[7].fields[1].values.buffer[0] * 100, 0, 0, 0, 0],\n        theta: [\"0\", \"30\", \"60\", \"90\", \"120\", \"150\", \"180\", \"210\", \"240\", \"270\", \"300\", \"330\"],\n        name: \"210°-240°\",\n        marker: {color: \"rgb(0,125,255)\"},\n        type: \"barpolar\",\n        showlegend: false,\n        offset: 0,\n        hovertext: \"Obstructions between 210° and 240°\",\n        hoverinfo: \"text+r\"\n    },\n    {\n        r: [0, 0, 0, 0, 0, 0, 0, 0, data.series[8].fields[1].values.buffer[0] * 100, 0, 0, 0],\n        theta: [\"0\", \"30\", \"60\", \"90\", \"120\", \"150\", \"180\", \"210\", \"240\", \"270\", \"300\", \"330\"],\n        name: \"240°-270°\",\n        marker: {color: \"rgb(0,0,255)\"},\n        type: \"barpolar\",\n        showlegend: false,\n        offset: 0,\n        hovertext: \"Obstructions between 240° and 270°\",\n        hoverinfo: \"text+r\"\n    },\n    {\n        r: [0, 0, 0, 0, 0, 0, 0, 0, 0, data.series[9].fields[1].values.buffer[0] * 100, 0, 0],\n        theta: [\"0\", \"30\", \"60\", \"90\", \"120\", \"150\", \"180\", \"210\", \"240\", \"270\", \"300\", \"330\"],\n        name: \"270°-300°\",\n        marker: {color: \"rgb(125,0,255)\"},\n        type: \"barpolar\",\n        showlegend: false,\n        offset: 0,\n        hovertext: \"Obstructions between 270° and 300°\",\n        hoverinfo: \"text+r\"\n    },\n    {\n        r: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, data.series[10].fields[1].values.buffer[0] * 100, 0],\n        theta: [\"0\", \"30\", \"60\", \"90\", \"120\", \"150\", \"180\", \"210\", \"240\", \"270\", \"300\", \"330\"],\n        name: \"300°-330°\",\n        marker: {color: \"rgb(255,0,255)\"},\n        type: \"barpolar\",\n        showlegend: false,\n        offset: 0,\n        hovertext: \"Obstructions between 300° and 330°\",\n        hoverinfo: \"text+r\"\n    },\n    {\n        r: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, data.series[11].fields[1].values.buffer[0] * 100],\n        theta: [\"0\", \"30\", \"60\", \"90\", \"120\", \"150\", \"180\", \"210\", \"240\", \"270\", \"300\", \"330\"],\n        name: \"330°-360°\",\n        marker: {color: \"rgb(255,0,125)\"},\n        type: \"barpolar\",\n        showlegend: false,\n        offset: 0,\n        hovertext: \"Obstructions between 330° and 360°\",\n        hoverinfo: \"text+r\"\n    }\n]\nvar layout = {\n    font: {size: 12},\n    legend: {font: {size: 10}},\n    polar: {\n        barmode: \"overlay\",\n        bargap: 0,\n        radialaxis: {ticksuffix: \"%\", angle: 45, dtick: 10},\n        angularaxis: {direction: \"clockwise\"}\n    }\n}\n\nreturn {data: data, layout: layout}\n"
       },
-      "percentage": false,
-      "pluginVersion": "7.5.5",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "7.4.5",
       "targets": [
         {
           "exemplar": true,
-          "expr": "starlink_dish_wedge_fraction_obstruction_ratio{instance=\"$DishID\"} * 100 > 0 ",
+          "expr": "starlink_dish_wedge_abs_fraction_obstruction_ratio{wedge=\"0\",instance=\"$DishID\"}",
+          "instant": true,
           "interval": "",
-          "legendFormat": "{{ wedge_name }}",
+          "legendFormat": "",
           "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": "24h",
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Wedge Fraction Obstructions",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": "Percent",
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
         },
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
+          "exemplar": true,
+          "expr": "starlink_dish_wedge_abs_fraction_obstruction_ratio{wedge=\"1\",instance=\"$DishID\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "starlink_dish_wedge_abs_fraction_obstruction_ratio{wedge=\"2\",instance=\"$DishID\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "starlink_dish_wedge_abs_fraction_obstruction_ratio{wedge=\"3\",instance=\"$DishID\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "D"
+        },
+        {
+          "exemplar": true,
+          "expr": "starlink_dish_wedge_abs_fraction_obstruction_ratio{wedge=\"4\",instance=\"$DishID\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "E"
+        },
+        {
+          "exemplar": true,
+          "expr": "starlink_dish_wedge_abs_fraction_obstruction_ratio{wedge=\"5\",instance=\"$DishID\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "F"
+        },
+        {
+          "exemplar": true,
+          "expr": "starlink_dish_wedge_abs_fraction_obstruction_ratio{wedge=\"6\",instance=\"$DishID\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "G"
+        },
+        {
+          "exemplar": true,
+          "expr": "starlink_dish_wedge_abs_fraction_obstruction_ratio{wedge=\"7\",instance=\"$DishID\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "H"
+        },
+        {
+          "exemplar": true,
+          "expr": "starlink_dish_wedge_abs_fraction_obstruction_ratio{wedge=\"8\",instance=\"$DishID\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "I"
+        },
+        {
+          "exemplar": true,
+          "expr": "starlink_dish_wedge_abs_fraction_obstruction_ratio{wedge=\"9\",instance=\"$DishID\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "J"
+        },
+        {
+          "exemplar": true,
+          "expr": "starlink_dish_wedge_abs_fraction_obstruction_ratio{wedge=\"10\",instance=\"$DishID\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "K"
+        },
+        {
+          "exemplar": true,
+          "expr": "starlink_dish_wedge_abs_fraction_obstruction_ratio{wedge=\"11\",instance=\"$DishID\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "L"
         }
       ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "title": "Current Wedge ABS Fraction Obstructions",
+      "type": "ae3e-plotly-panel"
     },
     {
       "aliasColors": {},
@@ -1217,7 +1282,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1346,7 +1411,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1454,7 +1519,7 @@
         "h": 5,
         "w": 6,
         "x": 18,
-        "y": 18
+        "y": 19
       },
       "hiddenSeries": false,
       "id": 4,
@@ -1475,7 +1540,7 @@
         "alertThreshold": false
       },
       "percentage": false,
-      "pluginVersion": "7.5.5",
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1525,6 +1590,200 @@
           "logBase": 1,
           "max": null,
           "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 4,
+      "gridPos": {
+        "h": 5,
+        "w": 9,
+        "x": 0,
+        "y": 23
+      },
+      "hiddenSeries": false,
+      "id": 37,
+      "interval": null,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "starlink_dish_wedge_fraction_obstruction_ratio{instance=\"$DishID\"} * 100 > 0 ",
+          "interval": "",
+          "legendFormat": "{{ wedge_name }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": "24h",
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Wedge Fraction Obstructions",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "Percent",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 4,
+      "gridPos": {
+        "h": 5,
+        "w": 9,
+        "x": 9,
+        "y": 23
+      },
+      "hiddenSeries": false,
+      "id": 52,
+      "interval": null,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "starlink_dish_wedge_abs_fraction_obstruction_ratio{instance=\"$DishID\"} * 100 > 0 ",
+          "interval": "",
+          "legendFormat": "{{ wedge_name }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": "24h",
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Wedge ABS Fraction Obstructions",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "Percent",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1599,5 +1858,5 @@
   "timezone": "",
   "title": "Starlink",
   "uid": "GG3mnflGz",
-  "version": 1
+  "version": 3
 }


### PR DESCRIPTION
First attempt, re-exported dashboard with the wedge ABS values exposed, I've left the scaling as was, although I'm wondering if it should be hard set to 0-100% so it doesn't autoscale.

https://github.com/danopstech/starlink/issues/12

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
