### PR TITLE
Change Units to Mbit

### DIFF
--- a/config/grafana/provisioning/dashboards/speedtest.json
+++ b/config/grafana/provisioning/dashboards/speedtest.json
@@ -110,13 +110,13 @@
       },
       "yaxes": [
         {
-          "format": "Bps",
+          "format": "decbits",
           "label": "",
           "logBase": 1,
           "max": null,
           "min": "0",
           "show": true
-        },
+},
         {
           "format": "short",
           "label": null,
@@ -149,7 +149,7 @@
               }
             ]
           },
-          "unit": "Bps"
+          "unit": "decbits"
         },
         "overrides": []
       },
@@ -223,7 +223,7 @@
               }
             ]
           },
-          "unit": "Bps"
+          "unit": "decbits"
         },
         "overrides": []
       },
@@ -600,7 +600,7 @@
               },
               {
                 "id": "unit",
-                "value": "Bps"
+                "value": "decbits"
               }
             ]
           },
@@ -622,7 +622,7 @@
               },
               {
                 "id": "unit",
-                "value": "Bps"
+                "value": "decbits"
               },
               {
                 "id": "max",


### PR DESCRIPTION
Change speedtest dashboard to show MegaBits as Value is in Megabits but dashboard was set to Bytes.

## Related Issue
https://github.com/danopstech/starlink/issues/11

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
